### PR TITLE
Avoid loading the McM's module from a folder in AFS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN npm run build
 
 # Build dependencies
 FROM python:3.11.7-alpine3.19@sha256:6aa46819a8ff43850e52f5ac59545b50c6d37ebd3430080421582af362afec97 AS build
+RUN apk add git
 RUN apk update && apk upgrade
 RUN pip install --upgrade pip setuptools wheel
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ pymongo==3.13.0
 PyJWT==2.8.0
 Authlib==1.3.0
 cryptography==42.0.5
-requests==2.31.0
 gunicorn==21.2.0
 Flask-Compress==1.14
+pdmv-http-client @ git+https://github.com/cms-PdmV/mcm_scripts.git

--- a/update_scripts/update_samples.py
+++ b/update_scripts/update_samples.py
@@ -3,22 +3,15 @@ Module handles update of all the samples
 """
 
 import json
-import sys
 import time
 import argparse
 import logging
 import hashlib
 import os
+from rest import McM
 from utils.grasp_database import Database as GrASPDatabase
 from utils.mcm_database import Database as McMDatabase
 from utils.utils import chained_request_to_steps
-
-default_mcm_tools_path = "/afs/cern.ch/cms/PPD/PdmV/tools/McM/"
-mcm_tools_path: str = os.getenv("MCM_TOOLS_PATH", default_mcm_tools_path)
-
-sys.path.append(mcm_tools_path)  # pylint: disable=wrong-import-order,import-error
-
-from rest import McM  # pylint: disable=wrong-import-position,wrong-import-order,import-error
 
 logger = logging.getLogger()
 


### PR DESCRIPTION
Related to: [#23](https://github.com/cms-PdmV/mcm_scripts/issues/23)

1. Install this module from its source code using `pip`.